### PR TITLE
feat: Add additional language support in windows.py

### DIFF
--- a/src/import_loco/core/platforms/windows.py
+++ b/src/import_loco/core/platforms/windows.py
@@ -34,5 +34,13 @@ class WindowsPlatform(Platform):
             "it": "IT",
             "es": "ES",
             "de": "DE",
+            "da": "DK",
+            "nl": "NL",
+            "fi": "FI",
+            "el": "GR",
+            "nb": "NO",
+            "pl": "PL",
+            "pt": "PT",
+            "sv": "SE",
         }
         return filename.format(language=language, country=countries[language])


### PR DESCRIPTION
This pull request expands the language-to-country mapping in the Windows platform code to support additional languages, ensuring that filenames are formatted correctly for more locales.

Localization support:

* Added mappings for Danish (`da`), Dutch (`nl`), Finnish (`fi`), Greek (`el`), Norwegian Bokmål (`nb`), Polish (`pl`), Portuguese (`pt`), and Swedish (`sv`) to their respective country codes in the `_format_destination_path` method in `src/import_loco/core/platforms/windows.py`.