### PR TITLE
feat: Add Qt platform support with .ts import and placeholder/Markdown normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ import_loco -v                      # Verbose mode for the curious
 ### Qt normalization
 
 Loco's Qt exporter emits Apple/printf-style placeholders and SwiftUI Markdown, which Qt doesn't understand at
-runtime. When importing `.ts` files, `import_loco` rewrites the text of every `<source>`, `<translation>`, and
-`<numerusform>` in place:
+runtime, and names each `<context>` after the string's group. When importing `.ts` files, `import_loco`
+rewrites the text of every `<source>`, `<translation>`, and `<numerusform>` in place:
 
 | From (Loco)                    | To (Qt)                            |
 |--------------------------------|------------------------------------|
@@ -75,6 +75,9 @@ runtime. When importing `.ts` files, `import_loco` rewrites the text of every `<
 | positional `%1$s`, `%2$@`      | `%1`, `%2` (index preserved)       |
 | integer specifier in a plural  | `%n` (Qt's count token)            |
 | `**bold**`                     | `<b>bold</b>`                      |
+
+It also **empties every `<context>` name**: the export is id-based and looked up at runtime with
+`qtTrId`/`qsTrId`, which only query the empty context, so a named context would make those ids unreachable.
 
 Numbering restarts per element, so a message's source and every translation stay consistent. `<extracomment>`
 context notes are left untouched (Qt's `lrelease` strips them from the compiled `.qm`).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ import_loco -v                      # Verbose mode for the curious
 |----------|--------------------------------------------------------------|------------------------|--------------------------------|
 | iOS      | `strings`, `stringsdict`, `infoplist`, `main_target_strings` | .strings, .stringsdict | `en.lproj/Localizable.strings` |
 | macOS    | `strings`, `stringsdict`                                     | .strings, .stringsdict | `en.lproj/Localizable.strings` |
+| Qt       | `ts`                                                         | .ts (XML)              | `client_fr.ts`                 |
 | Windows  | `resx`                                                       | .resx                  | `Resources.en.resx`            |
 
 ## Configuration example
@@ -78,7 +79,7 @@ filters: [ common ]  # Optional for additional Loco tag filters
 
 | Option                         | Required | Description                                               |
 |--------------------------------|----------|-----------------------------------------------------------|
-| `platform`                     | Yes      | `ios`, `macos`, or `windows`                              |
+| `platform`                     | Yes      | `ios`, `macos`, `qt`, or `windows`                        |
 | `localizable_path`             | Yes      | Path to your localization files                           |
 | `main_target_localizable_path` | No       | iOS only: path for InfoPlist.strings                      |
 | `languages`                    | No       | List of language codes (defaults to `de, en, es, fr, it`) |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Import Loco
 
 Your friendly neighborhood localization importer! A modern Python CLI tool that fetches your localized strings
-from [Loco](https://localise.biz/) and drops them right into your iOS, macOS, or Windows project. No fuss, no muss.
+from [Loco](https://localise.biz/) and drops them right into your iOS, macOS, Qt, or Windows project. No fuss, no muss.
 
 ## What's in the Box?
 
-- **Multi-Platform Love**: iOS, macOS, and Windows are all invited to the party
-- **All the Formats**: `.strings`, `.stringsdict`, and `.resx` — we speak your language(s)
+- **Multi-Platform Love**: iOS, macOS, Qt, and Windows are all invited to the party
+- **All the Formats**: `.strings`, `.stringsdict`, `.ts`, and `.resx` — we speak your language(s)
 - **Validation Superpowers**: Catches typos, wrong punctuation, and those sneaky straight apostrophes before they reach production
 - **YAML Config**: Because life's too short for INI files
 - **Secure by Default**: API keys stay safe in env vars or separate files
@@ -62,6 +62,22 @@ import_loco -v                      # Verbose mode for the curious
 | macOS    | `strings`, `stringsdict`                                     | .strings, .stringsdict | `en.lproj/Localizable.strings` |
 | Qt       | `ts`                                                         | .ts (XML)              | `client_fr.ts`                 |
 | Windows  | `resx`                                                       | .resx                  | `Resources.en.resx`            |
+
+### Qt normalization
+
+Loco's Qt exporter emits Apple/printf-style placeholders and SwiftUI Markdown, which Qt doesn't understand at
+runtime. When importing `.ts` files, `import_loco` rewrites the text of every `<source>`, `<translation>`, and
+`<numerusform>` in place:
+
+| From (Loco)                    | To (Qt)                            |
+|--------------------------------|------------------------------------|
+| `%@`, `%lld`, `%d`, …          | `%1`, `%2`, … (numbered in order)  |
+| positional `%1$s`, `%2$@`      | `%1`, `%2` (index preserved)       |
+| integer specifier in a plural  | `%n` (Qt's count token)            |
+| `**bold**`                     | `<b>bold</b>`                      |
+
+Numbering restarts per element, so a message's source and every translation stay consistent. `<extracomment>`
+context notes are left untouched (Qt's `lrelease` strips them from the compiled `.qm`).
 
 ## Configuration example
 
@@ -131,7 +147,7 @@ pdm run ruff check
 → Set `LOCO_API_KEY` env var or create `.import_loco_api` file
 
 **"Unsupported platform"**
-→ Use `ios`, `macos`, or `windows`
+→ Use `ios`, `macos`, `qt`, or `windows`
 
 **"Resource type not supported"**
 → Check the platform table above for valid resource types

--- a/src/import_loco/core/loco/platform_import.py
+++ b/src/import_loco/core/loco/platform_import.py
@@ -99,6 +99,7 @@ def _move_files_to_destination(platform: Platform, folder: str, resource_type: s
         try:
             shutil.copy2(source_path, destination_path)
             logger.debug("Copied %s to %s", source_path, destination_path)
+            platform.post_process(destination_path, language)
         except FileNotFoundError as exc:
             raise LocoParserError(
                 f"Missing source translation file for language '{language}' at '{source_path}'. "

--- a/src/import_loco/core/loco/platform_import.py
+++ b/src/import_loco/core/loco/platform_import.py
@@ -83,6 +83,7 @@ def _extract_archive(archive_path: str) -> str:
 
 
 def _move_files_to_destination(platform: Platform, folder: str, resource_type: str) -> None:
+    platform.prepare_import(folder)
     languages = platform.get_supported_languages()
 
     for language in languages:

--- a/src/import_loco/core/normalizers/qt_normalizer.py
+++ b/src/import_loco/core/normalizers/qt_normalizer.py
@@ -16,6 +16,14 @@ This module rewrites, in place, the text of every ``<source>``,
 Numbering restarts at each element, which keeps the source and every
 translation of the same message consistent: Apple ``%@`` ordering is by
 appearance, so numbering by appearance matches the original semantics.
+
+It also **empties every ``<context>`` name**. The export is id-based (each
+``<message>`` carries an ``id``) and is meant to be looked up at runtime with
+``qtTrId``/``qsTrId``, which only ever query the *empty* context. Loco writes each
+string's category into the ``<context>`` name (``main``, ``Settings``, ``Description
+for … error`` …), which would scatter the ids across named contexts and make them
+unreachable; blanking the name files every message under the empty context, keyed
+by its id alone.
 """
 
 import logging
@@ -44,6 +52,11 @@ _INT_CONV = frozenset("diuxX")
 # SwiftUI bold. Text content is XML-escaped, so we inject escaped angle brackets
 # to keep the .ts valid; lrelease decodes them back to <b>…</b> in the .qm.
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.S)
+
+# Loco stores each string's category as the <context> name, but qtTrId/qsTrId only look up the
+# empty context. Blanking every name keys each message by its id alone. (<name> only ever appears
+# as a context name in a .ts, so a document-wide sub is safe.)
+_CONTEXT_NAME_RE = re.compile(r"(<name>)[^<]*(</name>)")
 
 _MESSAGE_RE = re.compile(r"<message\b.*?</message>", re.S)
 _SOURCE_RE = re.compile(r"(<source>)(.*?)(</source>)", re.S)
@@ -101,7 +114,9 @@ def _normalize_message(block: str) -> str:
 
 
 def normalize(content: str) -> str:
-    """Return *content* (a Qt ``.ts`` document) with placeholders and Markdown converted."""
+    """Return *content* (a Qt ``.ts`` document) with contexts, placeholders and Markdown converted."""
+    # Blank Loco's category names so every id resolves via qtTrId's empty-context lookup.
+    content = _CONTEXT_NAME_RE.sub(r"\1\2", content)
     return _MESSAGE_RE.sub(lambda m: _normalize_message(m.group(0)), content)
 
 

--- a/src/import_loco/core/normalizers/qt_normalizer.py
+++ b/src/import_loco/core/normalizers/qt_normalizer.py
@@ -1,0 +1,119 @@
+"""Normalize Loco's Qt ``.ts`` export into Qt-consumable form.
+
+Loco's Qt exporter (flagged "LEGACY") emits Apple/printf-style placeholders
+(``%@``, ``%lld``, ``%1$s``) and SwiftUI Markdown (``**bold**``). Neither is
+understood by Qt at runtime: ``QString::arg`` only knows ``%1``…``%99`` and the
+plural token ``%n``, and ``Text`` renders HTML rich text, not Markdown.
+
+This module rewrites, in place, the text of every ``<source>``,
+``<translation>`` and ``<numerusform>`` element:
+
+* ``%@`` / ``%lld`` / ``%d`` …            → ``%1``, ``%2`` … (in order)
+* positional ``%1$s`` / ``%2$@`` …        → ``%1``, ``%2`` (index preserved)
+* an integer specifier inside a plural    → ``%n`` (Qt's count token)
+* ``**bold**``                            → ``&lt;b&gt;bold&lt;/b&gt;``
+
+Numbering restarts at each element, which keeps the source and every
+translation of the same message consistent: Apple ``%@`` ordering is by
+appearance, so numbering by appearance matches the original semantics.
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Conversion specifiers that actually occur in kDrive catalogs. Restricting the
+# set keeps a literal '%' in prose from ever being mistaken for a placeholder.
+_CONV = r"[@sdiufxX]"
+_LEN = r"(?:hh|h|ll|l|L|z|j|t)?"
+
+# One printf/Apple placeholder:
+#   %%            escaped percent (left untouched)
+#   %1$s %2$@     positional: explicit argument index
+#   %@ %lld %d …  non-positional: numbered by order of appearance
+_TOKEN_RE = re.compile(
+    r"%%"
+    r"|%(?P<pos>\d+)\$" + _LEN + _CONV
+    + r"|%[+\-# 0]*\d*(?:\.\d+)?" + _LEN + r"(?P<conv>" + _CONV + r")"
+)
+
+# Integer conversions become Qt's ``%n`` count token inside a plural form.
+_INT_CONV = frozenset("diuxX")
+
+# SwiftUI bold. Text content is XML-escaped, so we inject escaped angle brackets
+# to keep the .ts valid; lrelease decodes them back to <b>…</b> in the .qm.
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.S)
+
+_MESSAGE_RE = re.compile(r"<message\b.*?</message>", re.S)
+_SOURCE_RE = re.compile(r"(<source>)(.*?)(</source>)", re.S)
+_NUMERUS_RE = re.compile(r"(<numerusform>)(.*?)(</numerusform>)", re.S)
+_TRANSLATION_RE = re.compile(r"(<translation\b[^>]*>)(.*?)(</translation>)", re.S)
+
+
+def _convert_placeholders(text: str, in_plural: bool) -> str:
+    counter = [1]
+
+    def repl(match: "re.Match[str]") -> str:
+        token = match.group(0)
+        if token == "%%":
+            return token
+        pos = match.group("pos")
+        if pos is not None:
+            return "%" + pos
+        if in_plural and match.group("conv") in _INT_CONV:
+            return "%n"
+        number = counter[0]
+        counter[0] += 1
+        return "%%%d" % number
+
+    return _TOKEN_RE.sub(repl, text)
+
+
+def _convert_markdown(text: str) -> str:
+    return _BOLD_RE.sub(r"&lt;b&gt;\1&lt;/b&gt;", text)
+
+
+def _convert_element_text(text: str, in_plural: bool) -> str:
+    return _convert_markdown(_convert_placeholders(text, in_plural))
+
+
+def _normalize_message(block: str) -> str:
+    # A plural message wraps its forms in <numerusform>; its <source> then also
+    # carries the count placeholder and must be treated as plural too.
+    is_plural = "<numerusform>" in block
+
+    block = _SOURCE_RE.sub(
+        lambda m: m.group(1) + _convert_element_text(m.group(2), is_plural) + m.group(3),
+        block,
+    )
+    if is_plural:
+        block = _NUMERUS_RE.sub(
+            lambda m: m.group(1) + _convert_element_text(m.group(2), True) + m.group(3),
+            block,
+        )
+    else:
+        block = _TRANSLATION_RE.sub(
+            lambda m: m.group(1) + _convert_element_text(m.group(2), False) + m.group(3),
+            block,
+        )
+    return block
+
+
+def normalize(content: str) -> str:
+    """Return *content* (a Qt ``.ts`` document) with placeholders and Markdown converted."""
+    return _MESSAGE_RE.sub(lambda m: _normalize_message(m.group(0)), content)
+
+
+def normalize_file(path: str) -> None:
+    """Rewrite the Qt ``.ts`` file at *path* in place if normalization changes anything."""
+    with open(path, "r", encoding="utf-8") as handle:
+        content = handle.read()
+
+    converted = normalize(content)
+    if converted == content:
+        return
+
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(converted)
+    logger.debug("Normalized Qt placeholders and markdown in %s", path)

--- a/src/import_loco/core/parsers/qt_ts_parser.py
+++ b/src/import_loco/core/parsers/qt_ts_parser.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Dict
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
+
+from import_loco.core.exceptions import LocoParserError
+from import_loco.core.parsers.translations_parser import TranslationsParser
+
+logger = logging.getLogger(__name__)
+
+
+class QtTsTranslationsParser(TranslationsParser):
+    """Parser for Qt Linguist .ts XML files.
+
+    Supports both XLIFF-style messages (with an ``id`` attribute) and classic
+    Qt-style messages (keyed by context name + source text).
+    """
+
+    def parse(self, filename: str) -> Dict[str, str]:
+        try:
+            tree = ElementTree.parse(filename)
+            root = tree.getroot()
+
+            data = {}
+
+            for context in root.findall("context"):
+                context_name = context.findtext("name") or ""
+
+                for message in context.findall("message"):
+                    translation_el = message.find("translation")
+                    if translation_el is None:
+                        continue
+
+                    # Skip unfinished/vanished translations
+                    translation_type = translation_el.get("type", "")
+                    if translation_type in ("unfinished", "vanished"):
+                        continue
+
+                    translation = translation_el.text or ""
+
+                    # Prefer the XLIFF-style ``id`` attribute as key; fall back
+                    # to ``context_name.source_text`` for classic Qt .ts files.
+                    message_id = message.get("id")
+                    if message_id:
+                        key = message_id
+                    else:
+                        source_text = message.findtext("source") or ""
+                        key = f"{context_name}.{source_text}" if context_name else source_text
+
+                    data[key] = translation
+
+            logger.debug("Successfully parsed %d translations from %s", len(data), filename)
+            return data
+
+        except FileNotFoundError:
+            raise LocoParserError(f"Qt .ts file not found: {filename}")
+        except ParseError as e:
+            raise LocoParserError(f"Invalid XML in Qt .ts file {filename}: {e}")
+        except Exception as e:
+            raise LocoParserError(f"Failed to parse Qt .ts file {filename}: {e}")

--- a/src/import_loco/core/parsers/qt_ts_parser.py
+++ b/src/import_loco/core/parsers/qt_ts_parser.py
@@ -36,8 +36,6 @@ class QtTsTranslationsParser(TranslationsParser):
                     if translation_type in ("unfinished", "vanished"):
                         continue
 
-                    translation = translation_el.text or ""
-
                     # Prefer the XLIFF-style ``id`` attribute as key; fall back
                     # to ``context_name.source_text`` for classic Qt .ts files.
                     message_id = message.get("id")
@@ -47,7 +45,16 @@ class QtTsTranslationsParser(TranslationsParser):
                         source_text = message.findtext("source") or ""
                         key = f"{context_name}.{source_text}" if context_name else source_text
 
-                    data[key] = translation
+                    # Plural messages stok et core each form in a separate
+                    # ``<numerusform>`` child; ``translation_el.text`` would only
+                    # capture the whitespace before the first child, so emit one
+                    # entry per plural form (e.g. ``key[0]``, ``key[1]``).
+                    numerus_forms = translation_el.findall("numerusform")
+                    if numerus_forms:
+                        for index, form in enumerate(numerus_forms):
+                            data[f"{key}-{index}"] = (form.text or "").strip()
+                    else:
+                        data[key] = (translation_el.text or "").strip()
 
             logger.debug("Successfully parsed %d translations from %s", len(data), filename)
             return data

--- a/src/import_loco/core/platforms/platform.py
+++ b/src/import_loco/core/platforms/platform.py
@@ -73,6 +73,13 @@ class Platform(ABC):
         Override in subclasses to derive runtime context from the archive structure.
         """
 
+    def post_process(self, destination_path: str, language: str) -> None:
+        """Called after a resource file has been copied to its destination.
+
+        Override in subclasses to normalize or transform the written file in place.
+        No-op by default.
+        """
+
     def should_import_resource(self, resource_type: str) -> bool:
         config = self._get_resource_config(resource_type)
         return self.config.get(config.config_key, "") != ""

--- a/src/import_loco/core/platforms/platform.py
+++ b/src/import_loco/core/platforms/platform.py
@@ -67,6 +67,12 @@ class Platform(ABC):
         file_path = self._format_destination_path(language, config.destination_filename)
         return f"{base_path}/{file_path}"
 
+    def prepare_import(self, folder: str) -> None:
+        """Called before moving files, with the path of the extracted archive folder.
+
+        Override in subclasses to derive runtime context from the archive structure.
+        """
+
     def should_import_resource(self, resource_type: str) -> bool:
         config = self._get_resource_config(resource_type)
         return self.config.get(config.config_key, "") != ""

--- a/src/import_loco/core/platforms/platform_registry.py
+++ b/src/import_loco/core/platforms/platform_registry.py
@@ -5,6 +5,7 @@ from import_loco.core.exceptions import LocoConfigError
 from import_loco.core.platforms.platform import Platform
 from import_loco.core.platforms.apple.ios_platform import IOSPlatform
 from import_loco.core.platforms.apple.macos_platform import MacOSPlatform
+from import_loco.core.platforms.qt_platform import QtPlatform
 from import_loco.core.platforms.windows import WindowsPlatform
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 _PLATFORM_REGISTRY: Dict[str, Type[Platform]] = {
     "ios": IOSPlatform,
     "macos": MacOSPlatform,
+    "qt": QtPlatform,
     "windows": WindowsPlatform,
 }
 

--- a/src/import_loco/core/platforms/qt_platform.py
+++ b/src/import_loco/core/platforms/qt_platform.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import Any, Dict, List
 
+from import_loco.core.exceptions import LocoParserError
 from import_loco.core.parsers.qt_ts_parser import QtTsTranslationsParser
 from import_loco.core.platforms.platform import Platform
 from import_loco.core.normalizers.qt_normalizer import normalize_file
@@ -47,12 +48,15 @@ class QtPlatform(Platform):
         # We scan the archive to discover that prefix instead of requiring it in
         # the config, so the platform works for any Loco project out of the box.
         matches = glob.glob(os.path.join(folder, "translations", "*_*.ts"))
-        if matches:
-            basename = os.path.basename(matches[0])               # e.g. "kdrive-desktop_fr.ts"
-            self._loco_project_name = basename.rsplit("_", 1)[0]  # "kdrive-desktop"
-            logger.debug("Detected Loco project name from archive: %s", self._loco_project_name)
-        else:
-            logger.warning("No .ts files found in archive translations folder")
+        if not matches:
+            raise LocoParserError(
+                f"No 'translations/*_*.ts' files found in archive folder '{folder}'. "
+                "The Loco archive may be empty or use an unexpected layout."
+            )
+
+        basename = os.path.basename(matches[0])               # e.g. "kdrive-desktop_fr.ts"
+        self._loco_project_name = basename.rsplit("_", 1)[0]  # "kdrive-desktop"
+        logger.debug("Detected Loco project name from archive: %s", self._loco_project_name)
 
     def post_process(self, destination_path: str, language: str) -> None:
         # Loco's Qt exporter emits Apple/printf placeholders (%@, %lld) and

--- a/src/import_loco/core/platforms/qt_platform.py
+++ b/src/import_loco/core/platforms/qt_platform.py
@@ -1,4 +1,6 @@
+import glob
 import logging
+import os
 from typing import Any, Dict, List
 
 from import_loco.core.parsers.qt_ts_parser import QtTsTranslationsParser
@@ -11,29 +13,16 @@ logger = logging.getLogger(__name__)
 class QtPlatform(Platform):
     """Platform for Qt desktop applications using Qt Linguist .ts files.
 
-    Loco exports one ``{loco_project_name}_{language}.ts`` file per locale
-    inside a ``translations/`` folder within the ZIP archive.  Those files are
-    copied verbatim to ``{localizable_path}/client_{language}.ts``.
+    Loco exports one ``{project_name}_{language}.ts`` file per locale inside a
+    ``translations/`` folder within the ZIP archive.  The project name is
+    derived automatically from the archive folder name
+    (e.g. ``kdrive-desktop-ts-archive`` → ``kdrive-desktop``).
 
-    Required YAML config fields
-    ---------------------------
-    loco_project_name : str
-        The project slug as it appears in the Loco export filenames
-        (e.g. ``kdrive-desktop`` for ``kdrive-desktop_fr.ts``).
-    localizable_path : str
-        Absolute path to the directory where the ``.ts`` files should be written.
-
-    Optional YAML config fields
-    ---------------------------
-    languages : list[str]
-        Defaults to ``de, da, el, en, es, fi, fr, it, nb, nl, pl, pt, sv``.
-    destination_filename : str
-        Pattern for the output filename. Use ``{language}`` as a placeholder.
-        Defaults to ``client_{language}.ts``.
+    The files are written to ``{localizable_path}/client_{language}.ts``.
     """
 
     default_languages: List[str] = ["de", "da", "el", "en", "es", "fi", "fr", "it", "nb", "nl", "pl", "pt", "sv"]
-    required_config_fields: List[str] = ["localizable_path", "loco_api_key", "loco_project_name"]
+    required_config_fields: List[str] = ["localizable_path", "loco_api_key"]
 
     resource_type_configs = {
         "ts": ResourceTypeConfig(
@@ -41,8 +30,6 @@ class QtPlatform(Platform):
             parser_class=QtTsTranslationsParser,
             loco_filters=[],
             archive_endpoint="ts.zip",
-            # Placeholder — the real source path is built in _format_source_path
-            # from the ``loco_project_name`` config value.
             source_filename="{language}.ts",
             destination_filename="client_{language}.ts",
             config_key="localizable_path",
@@ -51,11 +38,23 @@ class QtPlatform(Platform):
 
     def __init__(self, config: Dict[str, Any]) -> None:
         super().__init__(config)
+        self._loco_project_name: str = ""
+
+    def prepare_import(self, folder: str) -> None:
+        # the Qt TS export names each file "{project_slug}_{language}.ts" where
+        # the slug matches the Loco project identifier (e.g. "kdrive-desktop").
+        # We scan the archive to discover that prefix instead of requiring it in
+        # the config, so the platform works for any Loco project out of the box.
+        matches = glob.glob(os.path.join(folder, "translations", "*_*.ts"))
+        if matches:
+            basename = os.path.basename(matches[0])               # e.g. "kdrive-desktop_fr.ts"
+            self._loco_project_name = basename.rsplit("_", 1)[0]  # "kdrive-desktop"
+            logger.debug("Detected Loco project name from archive: %s", self._loco_project_name)
+        else:
+            logger.warning("No .ts files found in archive translations folder")
 
     def _format_source_path(self, language: str, filename: str) -> str:
-        project_name = self.config["loco_project_name"]
-        return f"translations/{project_name}_{language}.ts"
+        return f"translations/{self._loco_project_name}_{language}.ts"
 
     def _format_destination_path(self, language: str, filename: str) -> str:
-        pattern = self.config.get("destination_filename", "client_{language}.ts")
-        return pattern.format(language=language)
+        return filename.format(language=language)

--- a/src/import_loco/core/platforms/qt_platform.py
+++ b/src/import_loco/core/platforms/qt_platform.py
@@ -1,0 +1,61 @@
+import logging
+from typing import Any, Dict, List
+
+from import_loco.core.parsers.qt_ts_parser import QtTsTranslationsParser
+from import_loco.core.platforms.platform import Platform
+from import_loco.core.platforms.resource_type_config import ResourceTypeConfig
+
+logger = logging.getLogger(__name__)
+
+
+class QtPlatform(Platform):
+    """Platform for Qt desktop applications using Qt Linguist .ts files.
+
+    Loco exports one ``{loco_project_name}_{language}.ts`` file per locale
+    inside a ``translations/`` folder within the ZIP archive.  Those files are
+    copied verbatim to ``{localizable_path}/client_{language}.ts``.
+
+    Required YAML config fields
+    ---------------------------
+    loco_project_name : str
+        The project slug as it appears in the Loco export filenames
+        (e.g. ``kdrive-desktop`` for ``kdrive-desktop_fr.ts``).
+    localizable_path : str
+        Absolute path to the directory where the ``.ts`` files should be written.
+
+    Optional YAML config fields
+    ---------------------------
+    languages : list[str]
+        Defaults to ``de, da, el, en, es, fi, fr, it, nb, nl, pl, pt, sv``.
+    destination_filename : str
+        Pattern for the output filename. Use ``{language}`` as a placeholder.
+        Defaults to ``client_{language}.ts``.
+    """
+
+    default_languages: List[str] = ["de", "da", "el", "en", "es", "fi", "fr", "it", "nb", "nl", "pl", "pt", "sv"]
+    required_config_fields: List[str] = ["localizable_path", "loco_api_key", "loco_project_name"]
+
+    resource_type_configs = {
+        "ts": ResourceTypeConfig(
+            name="ts",
+            parser_class=QtTsTranslationsParser,
+            loco_filters=[],
+            archive_endpoint="ts.zip",
+            # Placeholder — the real source path is built in _format_source_path
+            # from the ``loco_project_name`` config value.
+            source_filename="{language}.ts",
+            destination_filename="client_{language}.ts",
+            config_key="localizable_path",
+        ),
+    }
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        super().__init__(config)
+
+    def _format_source_path(self, language: str, filename: str) -> str:
+        project_name = self.config["loco_project_name"]
+        return f"translations/{project_name}_{language}.ts"
+
+    def _format_destination_path(self, language: str, filename: str) -> str:
+        pattern = self.config.get("destination_filename", "client_{language}.ts")
+        return pattern.format(language=language)

--- a/src/import_loco/core/platforms/qt_platform.py
+++ b/src/import_loco/core/platforms/qt_platform.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 from import_loco.core.parsers.qt_ts_parser import QtTsTranslationsParser
 from import_loco.core.platforms.platform import Platform
+from import_loco.core.normalizers.qt_normalizer import normalize_file
 from import_loco.core.platforms.resource_type_config import ResourceTypeConfig
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,12 @@ class QtPlatform(Platform):
             logger.debug("Detected Loco project name from archive: %s", self._loco_project_name)
         else:
             logger.warning("No .ts files found in archive translations folder")
+
+    def post_process(self, destination_path: str, language: str) -> None:
+        # Loco's Qt exporter emits Apple/printf placeholders (%@, %lld) and
+        # SwiftUI markdown; rewrite them into Qt form (%1, %n, <b>) so the .ts
+        # is usable at runtime.
+        normalize_file(destination_path)
 
     def _format_source_path(self, language: str, filename: str) -> str:
         return f"translations/{self._loco_project_name}_{language}.ts"


### PR DESCRIPTION
Adds support for the **Qt** platform and Qt Linguist `.ts` files to `import_loco`, and normalizes Loco's export into a form Qt can actually consume at runtime.

## Qt platform & parser

* New `QtTsTranslationsParser` (`qt_ts_parser.py`) parsing Qt Linguist `.ts` XML, supporting both XLIFF-style (`id`) and classic (context + source) messages.
* New `QtPlatform` (`qt_platform.py`): auto-detects the Loco project name from the archive folder, configures `.ts` resource handling, and writes `client_{language}.ts`.
* Registered `QtPlatform` in the platform registry so it can be selected via `platform: qt`.

## `.ts` normalization (post-import)

Loco's Qt exporter (flagged "LEGACY") emits Apple/printf placeholders (`%@`, `%lld`, `%1$s`) and SwiftUI Markdown (`**bold**`) — none of which Qt understands: `QString::arg` only knows `%1`…`%99` and the plural token `%n`, and `Text` renders HTML, not Markdown. A post-import pass rewrites the text of every `<source>`, `<translation>`, and `<numerusform>`:

| From (Loco)                   | To (Qt)                           |
|-------------------------------|-----------------------------------|
| `%@`, `%lld`, `%d`, …         | `%1`, `%2`, … (numbered in order) |
| positional `%1$s`, `%2$@`     | `%1`, `%2` (index preserved)      |
| integer specifier in a plural | `%n` (Qt's count token)           |
| `**bold**`                    | `<b>bold</b>`                     |

* Numbering restarts per element, so a message's source and every translation stay consistent.
* `<extracomment>` context notes are left untouched (`lrelease` strips them from the compiled `.qm`).
* Lives in `core/normalizers/qt_normalizer.py`, wired through a new generic `Platform.post_process()` hook (no-op by default) called after each file is copied and overridden by `QtPlatform`.

## Core & docs

* Added a `prepare_import()` hook to the base `Platform` (overridden by `QtPlatform`) to derive runtime context from the extracted archive.
* `README.md` now documents Qt support, its configuration, and the normalization table.
